### PR TITLE
Handling Bad Requests

### DIFF
--- a/controllers/baseRemindersController.js
+++ b/controllers/baseRemindersController.js
@@ -1,4 +1,13 @@
-var baseRemindersController = function(baseRemindersService) {
+var baseRemindersController = function(baseRemindersService, httpResponseService) {
+
+  var _requiredFields = [
+    'name',
+    'message',
+    'detail',
+    'timeframes',
+    'category'
+  ];
+
 
   var getAll = function(req, res) {
 
@@ -21,6 +30,12 @@ var baseRemindersController = function(baseRemindersService) {
 
   var post = function(req, res) {
 
+    if (!httpResponseService.hasRequiredFields(req.body, _requiredFields)) {
+      res.status(400);
+      res.send(httpResponseService.getBadRequestResponse(_requiredFields));
+      return;
+    }
+
     var newBaseReminder = {
       name: req.body.name,
       message: req.body.message,
@@ -39,6 +54,12 @@ var baseRemindersController = function(baseRemindersService) {
   };
 
   var put = function(req, res) {
+
+    if (!httpResponseService.hasRequiredFields(req.body, _requiredFields)) {
+      res.status(400);
+      res.send(httpResponseService.getBadRequestResponse(_requiredFields));
+      return;
+    }
 
     var updatedBaseReminder = {
       name: req.body.name,

--- a/controllers/baseRemindersController.js
+++ b/controllers/baseRemindersController.js
@@ -31,8 +31,8 @@ var baseRemindersController = function(baseRemindersService, httpResponseService
   var post = function(req, res) {
 
     if (!httpResponseService.hasRequiredFields(req.body, _requiredFields)) {
-      res.status(400);
-      res.send(httpResponseService.getBadRequestResponse(_requiredFields));
+      res.status(422);
+      res.send(httpResponseService.getMissingFieldsResponse(_requiredFields));
       return;
     }
 
@@ -56,8 +56,8 @@ var baseRemindersController = function(baseRemindersService, httpResponseService
   var put = function(req, res) {
 
     if (!httpResponseService.hasRequiredFields(req.body, _requiredFields)) {
-      res.status(400);
-      res.send(httpResponseService.getBadRequestResponse(_requiredFields));
+      res.status(422);
+      res.send(httpResponseService.getMissingFieldsResponse(_requiredFields));
       return;
     }
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "chai": "^3.5.0",
     "gulp": "^3.8.11",
     "gulp-nodemon": "^2.0.3",
     "gulp-util": "^3.0.5",

--- a/routes/baseRemindersRoutes.js
+++ b/routes/baseRemindersRoutes.js
@@ -1,7 +1,8 @@
 var express = require('express');
 var router = express.Router();
+var httpResponseService = require('../services/httpResponseService');
 var baseRemindersService = require('../services/baseRemindersService');
-var baseRemindersController = require('../controllers/baseRemindersController')(baseRemindersService);
+var baseRemindersController = require('../controllers/baseRemindersController')(baseRemindersService, httpResponseService);
 
 var routes = function() {
 

--- a/services/httpResponseService.js
+++ b/services/httpResponseService.js
@@ -19,10 +19,10 @@ var httpResponseService = function() {
 
   };
 
-  var getBadRequestResponse = function(requiredFields) {
+  var getMissingFieldsResponse = function(requiredFields) {
 
     return {
-      status: 400,
+      status: 422,
       message: _assembleMessage('The following fields are required: ', requiredFields)
     }
 
@@ -30,7 +30,7 @@ var httpResponseService = function() {
 
   return {
     hasRequiredFields: hasRequiredFields,
-    getBadRequestResponse: getBadRequestResponse
+    getMissingFieldsResponse: getMissingFieldsResponse
   }
 
 };

--- a/services/httpResponseService.js
+++ b/services/httpResponseService.js
@@ -1,0 +1,38 @@
+var httpResponseService = function() {
+
+  var _assembleMessage = function(prefix, fields) {
+
+    var message = prefix;
+    fields.forEach(function(field) {
+      message += field + ', ';
+    });
+
+    return message.slice(0, -2);
+
+  };
+
+  var hasRequiredFields = function(data, requiredFields) {
+
+    return requiredFields.every(function(requiredField) {
+      return typeof data[requiredField] !== 'undefined'
+    });
+
+  };
+
+  var getBadRequestResponse = function(requiredFields) {
+
+    return {
+      status: 400,
+      message: _assembleMessage('The following fields are required: ', requiredFields)
+    }
+
+  };
+
+  return {
+    hasRequiredFields: hasRequiredFields,
+    getBadRequestResponse: getBadRequestResponse
+  }
+
+};
+
+module.exports = httpResponseService;

--- a/test/unit/baseRemindersController_spec.js
+++ b/test/unit/baseRemindersController_spec.js
@@ -314,9 +314,9 @@ describe('BaseReminders Controller', function() {
     };
 
     baseRemindersController.post(req, res);
-    assert.ok(res.status.calledWith(400));
+    assert.ok(res.status.calledWith(422));
     assert.ok(res.send.calledWith({
-      status: 400,
+      status: 422,
       message: 'The following fields are required: name, message, detail, timeframes, category'
     }));
 
@@ -343,9 +343,9 @@ describe('BaseReminders Controller', function() {
     };
 
     baseRemindersController.put(req, res);
-    assert.ok(res.status.calledWith(400));
+    assert.ok(res.status.calledWith(422));
     assert.ok(res.send.calledWith({
-      status: 400,
+      status: 422,
       message: 'The following fields are required: name, message, detail, timeframes, category'
     }));
 

--- a/test/unit/baseRemindersController_spec.js
+++ b/test/unit/baseRemindersController_spec.js
@@ -4,6 +4,8 @@ var assert = require('assert');
 var sinon = require('sinon');
 var httpMocks = require('node-mocks-http');
 
+var httpResponseService = require('../../services/httpResponseService');
+
 var mockBaseReminders = [
   {
     id: 1,
@@ -67,7 +69,7 @@ var mockBaseReminderService = {
 
 };
 
-var baseRemindersController = require('../../controllers/baseRemindersController.js')(mockBaseReminderService);
+var baseRemindersController = require('../../controllers/baseRemindersController.js')(mockBaseReminderService, httpResponseService());
 
 describe('BaseReminders Controller', function() {
 
@@ -290,6 +292,64 @@ describe('BaseReminders Controller', function() {
         category: 4
       }
     ]));
+
+  });
+
+  it('should return a 400 error with a message if not all required fields are provided on a post request', function() {
+
+    var req = {
+      body: {
+        message: 'A 3rd message',
+        detail: 'Yet more details',
+        lateMessage: 'Yet another late message',
+        lateDetail: 'Some more late details',
+        timeframes: [5],
+        category: 4
+      }
+    };
+
+    var res = {
+      status: sinon.spy(),
+      send: sinon.spy()
+    };
+
+    baseRemindersController.post(req, res);
+    assert.ok(res.status.calledWith(400));
+    assert.ok(res.send.calledWith({
+      status: 400,
+      message: 'The following fields are required: name, message, detail, timeframes, category'
+    }));
+
+
+
+  });
+
+  it('should return a 400 error with a message if not all required fields are provided on a put request', function() {
+
+    var req = {
+      body: {
+        message: 'A 3rd message',
+        detail: 'Yet more details',
+        lateMessage: 'Yet another late message',
+        lateDetail: 'Some more late details',
+        timeframes: [5],
+        category: 4
+      }
+    };
+
+    var res = {
+      status: sinon.spy(),
+      send: sinon.spy()
+    };
+
+    baseRemindersController.put(req, res);
+    assert.ok(res.status.calledWith(400));
+    assert.ok(res.send.calledWith({
+      status: 400,
+      message: 'The following fields are required: name, message, detail, timeframes, category'
+    }));
+
+
 
   });
 

--- a/test/unit/httpResponseService_spec.js
+++ b/test/unit/httpResponseService_spec.js
@@ -1,0 +1,59 @@
+'use strict';
+
+var assert = require('chai').assert;
+
+var httpResponseService = require('../../services/httpResponseService.js')();
+
+describe('httpResponseService.hasRequiredFields', function() {
+
+  it('should return true if all items in the requiredFields array are present as keys on the data object', function() {
+
+    var data = {
+      foo: 1,
+      bar: 2,
+      bazz: 3
+    };
+
+    var requiredFields = [
+      'foo',
+      'bar'
+    ];
+
+    var isValid = httpResponseService.hasRequiredFields(data, requiredFields);
+    assert.isOk(isValid);
+
+  });
+
+  it('should return false if item(s) in the requiredFields array are not present as keys the data object', function() {
+
+    var data = {
+      foo: 1,
+      bazz: 3
+    };
+
+    var requiredFields = [
+      'foo',
+      'bar'
+    ];
+
+    var isValid = httpResponseService.hasRequiredFields(data, requiredFields);
+    assert.isNotOk(isValid);
+
+  });
+
+});
+
+describe('httpResponseService.getBadRequestResponse', function() {
+
+  var fields = ['foo', 'bar'];
+
+  it('should return an object with a status property of 400 and a message stating required fields', function() {
+
+    var badRequestMessage = httpResponseService.getBadRequestResponse(fields);
+    assert.equal(badRequestMessage.status, 400);
+    assert.equal(badRequestMessage.message, 'The following fields are required: foo, bar');
+
+  });
+
+});
+

--- a/test/unit/httpResponseService_spec.js
+++ b/test/unit/httpResponseService_spec.js
@@ -43,14 +43,14 @@ describe('httpResponseService.hasRequiredFields', function() {
 
 });
 
-describe('httpResponseService.getBadRequestResponse', function() {
+describe('httpResponseService.getMissingFieldsResponse', function() {
 
   var fields = ['foo', 'bar'];
 
-  it('should return an object with a status property of 400 and a message stating required fields', function() {
+  it('should return an object with a status property of 422 and a message stating required fields', function() {
 
-    var badRequestMessage = httpResponseService.getBadRequestResponse(fields);
-    assert.equal(badRequestMessage.status, 400);
+    var badRequestMessage = httpResponseService.getMissingFieldsResponse(fields);
+    assert.equal(badRequestMessage.status, 422);
     assert.equal(badRequestMessage.message, 'The following fields are required: foo, bar');
 
   });


### PR DESCRIPTION
With the "happy paths" on the routes being close to being wrapped up, I wanted to start a discussion on handling API errors, rather than just committing, I'm creating a pull request so that we can have that discussion.

To start, I took the typical 400-Bad Request, if the required fields are not included in the body of POST and PUT requests.

To minimize code duplication, I created a new service `httpResponseService` to handle all response-related tasks. Right now, this service has two methods, `hasRequiredFields`, which returns true if the body has all required fields, and `getBadRequest` message, which creates a standard message to be passed through the HTTP response.

What do you think of this approach?