### PR TITLE
Base reminder response update

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,7 +18,7 @@ app.use(bodyParser.urlencoded({extended: false}));
 /* Setup cross-origin resource sharing */
 // TODO make origin configurable depending on environment
 app.use(cors({
-  origin: 'http://localhost:9000'
+  origin: ['http://localhost:9000', 'http://localhost:8000']
 }));
 
 /* Setup logging */

--- a/services/baseReminderService.js
+++ b/services/baseReminderService.js
@@ -1,10 +1,11 @@
 var models = require('../models/');
 var BaseReminder = models.BaseReminder;
 var Timeframe = models.Timeframe;
+var Category = models.Category;
 var baseReminderService = require('./baseDbService')(BaseReminder);
 
 baseReminderService.findAll = function() {
-  return BaseReminder.findAll({include: Timeframe}).then(function(resp) {
+  return BaseReminder.findAll({include: [Timeframe, Category]}).then(function(resp) {
     var baseReminders = resp.map(function(resp) {
       return resp.dataValues;
     });
@@ -13,7 +14,12 @@ baseReminderService.findAll = function() {
       baseReminder.timeframeIds = baseReminder.Timeframes.map(function(timeframeResp) {
         return timeframeResp.dataValues.id;
       });
+      baseReminder.timeframes = baseReminder.Timeframes.map(function(timeframeResp) {
+        return timeframeResp.dataValues.name;
+      });
+      baseReminder.categoryName = baseReminder.Category.dataValues.name;
       delete baseReminder.Timeframes;
+      delete baseReminder.Category;
       return baseReminder;
     });
 
@@ -42,7 +48,7 @@ baseReminderService.findAllIncludingTimeframes = function() {
 };
 
 baseReminderService.findById = function(id) {
-  return BaseReminder.findById(id, {include: Timeframe}).then(function(resp) {
+  return BaseReminder.findById(id, {include: [Timeframe, Category]}).then(function(resp) {
     if (!resp) {
       return [];
     }
@@ -52,7 +58,12 @@ baseReminderService.findById = function(id) {
     baseReminder.timeframeIds = baseReminder.Timeframes.map(function(timeframeResp) {
       return timeframeResp.dataValues.id;
     });
+    baseReminder.timeframes = baseReminder.Timeframes.map(function(timeframeResp) {
+      return timeframeResp.dataValues.name;
+    });
+    baseReminder.categoryName = baseReminder.Category.dataValues.name;
     delete baseReminder.Timeframes;
+    delete baseReminder.Category;
     return [baseReminder];
 
   });

--- a/test/unit/baseReminderService_spec.js
+++ b/test/unit/baseReminderService_spec.js
@@ -23,9 +23,12 @@ describe('The BaseReminders Service', function() {
       lateDetail: 'What to do about late essays',
       categoryId: 1,
       Timeframes: [
-        {dataValues: {id: 1}},
-        {dataValues: {id: 2}}
-      ]
+        {dataValues: {id: 1, name: '90 Days'}},
+        {dataValues: {id: 2, name: '60 Days'}}
+      ],
+      Category: {
+        dataValues: {id: 1, name: 'Essays'}
+      }
     }}, {dataValues: {
       id: 1,
       name: 'Get Recommendations',
@@ -35,8 +38,11 @@ describe('The BaseReminders Service', function() {
       lateDetail: 'What to do about late recommendations',
       categoryId: 1,
       Timeframes: [
-        {dataValues: {id: 3}}
-      ]
+        {dataValues: {id: 3, name: '30 Days'}}
+      ],
+      Category: {
+        dataValues: {id: 1, name: 'Essays'}
+      }
     }}];
     baseReminders = [{
       id: 1,
@@ -46,7 +52,9 @@ describe('The BaseReminders Service', function() {
       lateMessage: 'Your Essays are late',
       lateDetail: 'What to do about late essays',
       categoryId: 1,
-      timeframeIds: [1, 2]
+      timeframeIds: [1, 2],
+      timeframes: ['90 Days', '60 Days'],
+      categoryName: 'Essays'
     }, {
       id: 1,
       name: 'Get Recommendations',
@@ -55,7 +63,9 @@ describe('The BaseReminders Service', function() {
       lateMessage: 'Your recommendations are late',
       lateDetail: 'What to do about late recommendations',
       categoryId: 1,
-      timeframeIds: [3]
+      timeframeIds: [3],
+      timeframes: ['30 Days'],
+      categoryName: 'Essays'
     }];
   });
 


### PR DESCRIPTION
Updates the baseReminder `findAll()` and `findById()` methods to include the related timeframe/category names in addition to their IDs. This change simplifies displaying reminders in the admin interface.

This PR also updates CORS domains to include the dev admin URL.